### PR TITLE
Error checking on checkProject() + fix for quit() and setCPU() background issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ nvm install node
 ```shell
 $ npm install boidcmd -g
 ```
+> Please make sure you have "sudo" installed before running boidcmd.
 
 > now setup boid 
 
@@ -43,8 +44,13 @@ $ boidcmd setup
 ```
 ##### Note: The setup phase runs: 
 sudo apt install boinc-client -y
-##### If you want to manually install boinc, you can run this line yourself before running setup.
 
+##### Procedure to install boinc manually:
+
+```shell
+$ sudo apt install boinc-client -y
+$ boinccmd --dir /var/lib/boinc-client --daemon --allow_remote_gui_rpc
+```
 
 > additional commands can be found in the help menu
 

--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ function runBoid(){
 function quitBoid(){
     cmd.get(
         `
-            boinccmd kill
+            boinccmd --quit
         `,
         function(err, data, stderr){
             if (!err) {

--- a/index.js
+++ b/index.js
@@ -159,6 +159,10 @@ function projectCheck(){
         var threads = hostInfo.p_ncpus._text
         var model = hostInfo.p_model._text
 
+        if (project == undefined){
+           console.error("ERROR: you have no project attached, the boinc daemon is likely not installed or running.")
+           process.exit(-1)
+        }
         if (project.length > 1){
             console.error("ERROR: you have more than 1 project already configured, boidcmd requires you to only be attached to www.worldcommunitygrid.org")
             process.exit(-1)
@@ -301,6 +305,11 @@ function readFiles(callback) {
         var model = hostInfo.p_model._text
         var project = object.client_state.project
 
+        if (project == undefined){
+            console.error("ERROR: you have no project attached, the boinc daemon is likely not installed or running.")
+            process.exit(-1)
+        }
+
         if (project.length > 1){
             console.error("ERROR: you have more than 1 project already configured, boidcmd requires you to only be attached to www.worldcommunitygrid.org")
             process.exit(-1)
@@ -343,11 +352,10 @@ function readFiles(callback) {
                                         if(projectObject.wcgid == json.wcgid){
                                             console.log("Project setup Success!")
                                         }else {
-                                            console(" Device is using a different wcgid wcgid:"+json.wcgid)
+                                            console.log(" Device is using a different wcgid wcgid:"+json.wcgid)
                                         }
                                     }else{
-                                        //some other issue caused a problemi
-                                        console("wcgid is null, this should not happen.")
+                                        //some other issue caused a problem
                                     }
                                     console.log('Setup complete. Run "boidcmd status" to view project status')
                                     process.exit(0);

--- a/index.js
+++ b/index.js
@@ -212,6 +212,9 @@ function readGlobalPrefsOverride(){
             if (!err) {
                 console.log("Sucessfully set cpu limit")
                 spinner.stop()
+                console.log(data)
+                console.log(stderr)
+                process.exit(0);
             } else {
                console.log('error', err)
             }


### PR DESCRIPTION
This pull request does the following:
   * Verify that you have 1 project present before trying to register the device, this error happens if boinc is not running, and client_state.xml is not present or empty.
   * Verify that you don't have multiple projects defined , and report the error.
   * Added some clarification on pre-required package sudo as well as instructions
on how to install and start boinc manually.
   * fixed setCPU call not returning back to the shell prompt (reported in issue #5)
   * fixed quit command , it will now call boinccmd --quit correctly.

